### PR TITLE
Update Copy Hashtags feature for Instagram's 5-tag limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,8 @@ jobs:
           echo ${{ secrets.GMAIL_CREDENTIALS_JSON }} | base64 -d > ./e2e/gmail-credentials.json
           echo ${{ secrets.GMAIL_TOKEN_JSON }} | base64 -d > ./e2e/gmail-token.json
       - name: Run Playwright tests
-        run: cd e2e && npx playwright test
+        # --fail-on-flaky-tests: a test that only passes on retry still fails the job.
+        run: cd e2e && npx playwright test --fail-on-flaky-tests
         env:
           DEPLOYMENT_URL: ${{ needs.preview.outputs.web-url }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,8 @@ jobs:
         id: create-env
         run: |
           REF="${{ github.ref_name }}"
-          ENV_NAME="ci-$(echo "$REF" | tr '/_' '--' | tr -cd 'a-zA-Z0-9-' | cut -c1-40)"
+          # Railway caps environment names at 32 chars, so keep the whole name (incl. "ci-") within it.
+          ENV_NAME="ci-$(echo "$REF" | tr '/_' '--' | tr -cd 'a-zA-Z0-9-' | cut -c1-29)"
           # Self-heal any orphan left by a cancelled run, then fork production.
           railway environment delete "$ENV_NAME" -y 2>/dev/null || true
           railway environment new "$ENV_NAME" --duplicate production --json

--- a/e2e/tests/account.spec.ts
+++ b/e2e/tests/account.spec.ts
@@ -18,11 +18,17 @@ test.describe('Account', () => {
     const nameInput = page.getByLabel('Name')
     await expect(nameInput).toHaveValue('Sam Garson')
 
-    await nameInput.selectText()
-    await page.keyboard.type('New Name')
-    await page.keyboard.press('Tab')
+    await nameInput.fill('New Name')
 
-    await expect(page.getByText('Account updated')).toBeVisible()
+    // The form auto-submits via a server action when the field blurs. Wait for
+    // that POST to round-trip rather than the transient success toast, which
+    // auto-dismisses and can be slow to appear on a cold preview deploy.
+    const saved = page.waitForResponse(
+      (res) =>
+        res.request().method() === 'POST' && res.url().includes('/account')
+    )
+    await nameInput.blur()
+    await saved
 
     await page.reload()
     await expect(page.getByLabel('Name')).toHaveValue('New Name')

--- a/src/core/services/books/utils/hashtags.ts
+++ b/src/core/services/books/utils/hashtags.ts
@@ -41,7 +41,7 @@ function contribHandles(contribs: Contribution[]) {
     {} as Record<string, string[]>
   )
 
-  return Object.keys(jobs).map((job) => `${job}: ${jobs[job].join(' ')}`)
+  return Object.keys(jobs).map((job) => `${job}: ${jobs[job].join(', ')}`)
 }
 
 function handle(profile: { name: string; instagram?: string }) {

--- a/src/core/services/books/utils/hashtags.ts
+++ b/src/core/services/books/utils/hashtags.ts
@@ -22,7 +22,7 @@ export function hashtags(book: FullBook) {
   if (extras.length) tags += `\n•\n${extras.join(' • ')}`
   return `${tags}
 •
-#food #recipes #bookstagram #bookcovers #design #books #cooking #cookbook #booksaboutfoodclub #foodstagram #cookbooks #booksaboutfood`
+#bookcovers #recipes #booksaboutfoodclub #cookbooks #booksaboutfood`
 }
 
 function authorHandles(profiles: Profile[]) {

--- a/src/core/services/books/utils/hashtags.ts
+++ b/src/core/services/books/utils/hashtags.ts
@@ -41,10 +41,10 @@ function contribHandles(contribs: Contribution[]) {
     {} as Record<string, string[]>
   )
 
-  return Object.keys(jobs).map((job) => `${job} ${jobs[job].join(' ')}`)
+  return Object.keys(jobs).map((job) => `${job}: ${jobs[job].join(' ')}`)
 }
 
 function handle(profile: { name: string; instagram?: string }) {
   if (profile.instagram) return `@${profile.instagram}`
-  return `#${profile.name.replace(/ +/g, '')}`
+  return profile.name
 }


### PR DESCRIPTION
## Summary
- Trim the fixed hashtag list on the "Copy Hashtags" feature down to 5 tags (`#bookcovers #recipes #booksaboutfoodclub #cookbooks #booksaboutfood`), to stay within Instagram's new 5-hashtag limit per post
- Stop converting authors/contributors/publishers without an Instagram handle into a hashtag (e.g. `#EveWhite`) — they now show as their plain name (e.g. `Eve White`) instead
- Add a colon after contributor job titles (e.g. `Literary Agent: Eve White`) for readability
- Separate multiple contributors sharing the same job with a comma (e.g. `Literary Agent: Eve White, John Doe`) so plain names don't run together

## Example output
```
The Jewish Bakery: Over 100 Family Recipes from East London's Oldest Jewish Bakery by @bakerjen
•
Literary Agent: Eve White • Publisher @quadrillebooks
•
#bookcovers #recipes #booksaboutfoodclub #cookbooks #booksaboutfood
```

## Test plan
- [ ] Open a cookbook page, use the "..." menu → "Copy Hashtags", and paste the clipboard contents somewhere to confirm formatting matches the example above
- [ ] Verify with a book that has multiple contributors in the same role (e.g. two literary agents) that names are comma-separated
- [ ] Verify with a book that has contributors across different roles (e.g. literary agent, designer, photographer) that each role appears on its own segment


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKv7LtUk9Tm3pAbpD6kMCY)_