### PR TITLE
Only show colon for contributor roles without an Instagram handle

### DIFF
--- a/src/core/services/books/utils/hashtags.ts
+++ b/src/core/services/books/utils/hashtags.ts
@@ -41,7 +41,12 @@ function contribHandles(contribs: Contribution[]) {
     {} as Record<string, string[]>
   )
 
-  return Object.keys(jobs).map((job) => `${job}: ${jobs[job].join(', ')}`)
+  return Object.keys(jobs).map((job) => formatJob(job, jobs[job]))
+}
+
+function formatJob(job: string, handles: string[]) {
+  if (handles.every((h) => h.startsWith('@'))) return `${job} ${handles.join(' ')}`
+  return `${job}: ${handles.join(', ')}`
 }
 
 function handle(profile: { name: string; instagram?: string }) {


### PR DESCRIPTION
## Summary
- Follow-up to the "Copy Hashtags" formatting change merged in #8
- Job titles now read `Job @handle` (space, matching the original format) when every contributor in that role has an Instagram handle
- Job titles read `Job: Name, Name` (colon, comma-separated) only when a plain name is used as a fallback (no Instagram handle)

## Example output

With Instagram handles for everybody:
```
Librae: Third-Culture Recipes from a Cult New York Bakery by Dona Murad
•
Photographer @samaharris • Editor @scleworth • Food Stylist @kempkitchen • Prop Stylist @wilko_anna
•
Publisher @quadrillebooks
•
#bookcovers #recipes #booksaboutfoodclub #cookbooks #booksaboutfood
```

Without Instagram handles:
```
Librae: Third-Culture Recipes from a Cult New York Bakery by Dona Murad
•
Photographer: Sam A Harris • Editor: Stacey Cleworth • Food Stylist: Kempkitchen • Prop Stylist: Anna Wilkinson
•
Publisher @quadrillebooks
•
#bookcovers #recipes #booksaboutfoodclub #cookbooks #booksaboutfood
```

## Test plan
- [ ] Open a cookbook page, use the "..." menu → "Copy Hashtags", and paste the clipboard contents for a book where all contributors have Instagram handles — confirm no colon appears
- [ ] Repeat for a book where contributors have no Instagram handles — confirm the colon appears
- [ ] Repeat for a book with a mix of handles/no handles across different roles


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKv7LtUk9Tm3pAbpD6kMCY)_